### PR TITLE
ci: avoid request 2.32

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -7,5 +7,6 @@ molecule-plugins[docker]>=23.0.0
 paramiko>=3.0.0
 pre-commit>=3.2.0
 pylint>=3.0.0
+requests<2.32.0
 tox>=4.0.0
 yamllint>=1.30.0


### PR DESCRIPTION
see gh docker/docker-py issue #3256