### PR TITLE
update java and hotfix for install script

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,4 +6,5 @@ exclude_paths:
   - changelogs/changelog.yaml
 warn_list:
   - command-instead-of-shell
+  - risky-shell-pipe
   - yaml[line-length]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ tox -r -e py-ansible2.16-ubuntu20-jre8 -- test -s ubuntu20-jre8 --destroy=never
 ## Additional References
 
 - [Ansible community guide](https://docs.ansible.com/ansible/devel/community/index.html)
-- [Github Docs: Forking a repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo#forking-a-repository)
 - [Ansible Docs: `ansible-core` support matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix)
+- [Github Docs: Forking a repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo#forking-a-repository)
 - [MongoDB Docs: MongoDB Agent Compatibility Matrix](https://www.mongodb.com/docs/ops-manager/current/core/requirements/#operating-systems-compatible-with-the-mongodb-agent)
+- [Omada Controller Forum](https://community.tp-link.com/en/business/forum/582)
+- [RHEL: OpenJDK Life Cycle and Support Policy](https://access.redhat.com/articles/1299013)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ If you would like to manually download the tarball to your Ansible control host,
 
 See 'Example Playbooks' section for working examples. This role **does not configure the Omada controller**, it uses the default configuration values. It does set the service to run as a non-root user, you can change this by setting `omada_non_root: false`.
 
+### Java Requirements
+
+- Starting with Omada SDN `>=v5.15.20`, Java 17 is required and installed with this role.
+
 ### Install the Role
 
 You can install this role with the Ansible Galaxy CLI:
@@ -34,7 +38,7 @@ ansible-galaxy role install trfore.omada_install
 
 - MongoDB Community Edition, a role for installing it via a package manager is available - `trfore.mongodb_install`.
   - Omada SDN `< 5.14.20` only supported MongoDB 3 and 4.
-  - Omada SDN `>=5.14.20` now support up to MongoDB 7.
+  - Omada SDN `>=5.14.20` now supports up to MongoDB 7.
 - Apache Commons Daemon, `jsvc >= 1.1.0`, a role for installing the **latest** binary is available - `trfore.jsvc`.
 - You can install these roles by creating a `requirements.yml` file and running `ansible-galaxy install -r requirements.yml`.
 
@@ -47,7 +51,7 @@ ansible-galaxy role install trfore.omada_install
     - name: trfore.omada_install
   ```
 
-- NOTE: For **Ubuntu 20.04** targets, this role installs **OpenJDK 11**. While `jsvc` is available via APT, it is `< 1.1.0` and will **only work with OpenJDK 8**. If you prefer to use this older version, set `omada_dependencies` to the following in your playbook (see 'Example Playbooks' section below):
+- NOTE: For **Ubuntu 20.04** targets, this role installs **OpenJDK 17**. While `jsvc` is available via APT, it is `< 1.1.0` and will **only work with OpenJDK 8**. If you prefer to use this older version, set `omada_dependencies` to the following in your playbook (see 'Example Playbooks' section below):
 
   ```yaml
   omada_dependencies: ["curl", "openjdk-8-jre-headless", "jsvc"]
@@ -70,8 +74,8 @@ OS specific variables are listed below, along with default values (see `vars/mai
 
 | Variable           | Default                                       | Description                              | Required |
 | ------------------ | --------------------------------------------- | ---------------------------------------- | -------- |
-| omada_dependencies | `["curl", "openjdk-11-jre-headless"]`         | Required packages for Omada SDN (Debian) | No       |
-| omada_dependencies | `["curl", "java-11-openjdk-headless.x86_64"]` | Required packages for Omada SDN (RHEL)   | No       |
+| omada_dependencies | `["curl", "openjdk-17-jre-headless"]`         | Required packages for Omada SDN (Debian) | No       |
+| omada_dependencies | `["curl", "java-17-openjdk-headless.x86_64"]` | Required packages for Omada SDN (RHEL)   | No       |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # https://www.tp-link.com/us/support/download/omada-software-controller/
-omada_tar_src: https://static.tp-link.com/upload/software/2025/202501/20250109/Omada_SDN_Controller_v5.15.8.2_linux_x64.tar.gz
+omada_tar_src: https://static.tp-link.com/upload/software/2025/202503/20250321/Omada_SDN_Controller_v5.15.20.16_linux_x64.tar.gz
 omada_tar_src_remote: true
 omada_tar_dir: /var/tmp
 omada_non_root: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,7 +3,7 @@
   hosts: all
   gather_facts: true
   vars:
-    jdk_pkg: "{{ 'java-11-openjdk-headless' if ansible_os_family == 'RedHat' else 'openjdk-11-jre-headless' }}"
+    jdk_pkg: "{{ 'java-17-openjdk-headless' if ansible_os_family == 'RedHat' else 'openjdk-17-jre-headless' }}"
   tasks:
     - name: Test | Gather Package Facts
       ansible.builtin.package_facts:

--- a/omada.url
+++ b/omada.url
@@ -1,1 +1,1 @@
-https://static.tp-link.com/upload/software/2025/202501/20250109/Omada_SDN_Controller_v5.15.8.2_linux_x64.tar.gz
+https://static.tp-link.com/upload/software/2025/202503/20250321/Omada_SDN_Controller_v5.15.20.16_linux_x64.tar.gz

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements.txt
 ansible>=7.4
-ansible-compat==25.1.4
+ansible-compat==25.1.1
 ansible-lint>=6.14.0
 docker
 molecule==25.1.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,7 +69,7 @@
 
     - name: Run Omada Install Script
       become: true
-      ansible.builtin.command: "./install.sh -y"
+      ansible.builtin.shell: yes | ./install.sh
       args:
         chdir: "{{ omada_tar.dest }}"
         creates: /opt/tplink/EAPController/bin/control.sh

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,7 +74,7 @@
         chdir: "{{ omada_tar.dest }}"
         creates: /opt/tplink/EAPController/bin/control.sh
       register: omada_install
-      when: omada_tar.changed # noqa: no-handler
+      failed_when: omada_install.rc >= 1
       notify:
         - Remove tar folder
         - Enable omada service

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 omada_dependencies:
   - curl
-  - "{{ 'java-11-openjdk-headless.x86_64' if ansible_os_family == 'RedHat' else 'openjdk-11-jre-headless' }}" # OpenJDK 11 or higher, requires JSVC 1.1.0+
+  - "{{ 'java-17-openjdk-headless.x86_64' if ansible_os_family == 'RedHat' else 'openjdk-17-jre-headless' }}" # OpenJDK 11 or higher, requires JSVC 1.1.0+
 omada_tar_folder: "{{ omada_tar_src | basename | splitext | first | splitext | first }}"


### PR DESCRIPTION
- updates install to Java 17
- adds hotfix for the install script, while the CLI args are no longer working #59 
- update to Omada 5.15.20.16, #59 