### PR TITLE
fix: add support for Ansible 2.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [debian11, ubuntu2004, ubuntu2204] # limited by MongoDB 7 matrix
+        distro: [debian11, debian12, ubuntu2204] # limited by MongoDB 7 matrix
         experimental: [false]
         molecule_scenario: ["-s default", "-s root-user"]
         include:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,22 +21,25 @@ tox list
 tox -e lint run
 
 # run a specific test environment
-tox -e py-ansible2.16-ubuntu20-default run
+tox -e py3.11-ansible2.19-ubuntu20-default run
 
 # run all test in parallel
 tox run-parallel
 
+# run a group of test
+tox -f ubuntu run-parallel
+
 # pass Ansible Molecule args via Tox
-tox -e py-ansible2.16-ubuntu20-default run -- test --destroy=never
+tox -e py3.11-ansible2.19-ubuntu22-default run -- test --destroy=never
 ```
 
 - For iterative development and testing, the tox molecule environments are written to accept `molecule` arguments. This allows for codebase changes to be tested as you write across multiple distros and versions of `ansible-core`.
 
 ```sh
 # molecule converge
-tox -e py-ansible2.16-ubuntu20-default run -- converge -s default
+tox -e py3.11-ansible2.19-ubuntu22-default run -- converge -s default
 # molecule test w/o destroying the container
-tox -r -e py-ansible2.16-ubuntu20-jre8 -- test -s ubuntu20-jre8 --destroy=never
+tox -e py3.11-ansible2.19-ubuntu22-root -- test -s root-user --destroy=never
 ```
 
 ## Additional References

--- a/README.md
+++ b/README.md
@@ -51,12 +51,6 @@ ansible-galaxy role install trfore.omada_install
     - name: trfore.omada_install
   ```
 
-- NOTE: For **Ubuntu 20.04** targets, this role installs **OpenJDK 17**. While `jsvc` is available via APT, it is `< 1.1.0` and will **only work with OpenJDK 8**. If you prefer to use this older version, set `omada_dependencies` to the following in your playbook (see 'Example Playbooks' section below):
-
-  ```yaml
-  omada_dependencies: ["curl", "openjdk-8-jre-headless", "jsvc"]
-  ```
-
 ## Role Variables
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
@@ -128,6 +122,15 @@ OS specific variables are listed below, along with default values (see `vars/mai
     - name: Install Omada SDN
       role: trfore.omada_install
 ```
+
+## Depreciation Notice
+
+- **Currently the role still has the ability to install onto Ubuntu 20.04 systems using the method below, however, given 20.04 is EOL this feature will be removed in a future major release and is no longer tested.**
+- NOTE: For **Ubuntu 20.04** targets, this role installs **OpenJDK 17**. While `jsvc` is available via APT, it is `< 1.1.0` and will **only work with OpenJDK 8**. If you prefer to use this older version, set `omada_dependencies` to the following in your playbook (see 'Example Playbooks' section below):
+
+  ```yaml
+  omada_dependencies: ["curl", "openjdk-8-jre-headless", "jsvc"]
+  ```
 
 - If you would like to install OpenJDK JRE 8 and jsvc using APT (Ubuntu 20.04 Only)
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ ansible-galaxy role install trfore.omada_install
 - MongoDB Community: `7.0.x`
 - Omada SDN: `5.x.x`
 - CentOS Stream 9
-- Debian 11
-- Ubuntu 20.04 & 22.04
+- Debian 11 & 12
+- Ubuntu 22.04
 
 ## Requirements
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: "2.16"
+  min_ansible_version: "2.17"
 
   platforms:
     - name: Debian

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible-core>=2.16.0
+ansible-core>=2.17.0

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,10 +1,10 @@
 -r ../requirements.txt
 ansible>=7.4
-ansible-compat==25.1.1
+ansible-compat==25.8.2
 ansible-lint>=6.14.0
 docker
 molecule==25.1.0
-molecule-plugins==23.7.0
+molecule-plugins==25.8.12
 paramiko>=3.0.0
 pre-commit>=3.2.0
 pylint>=3.0.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Check Required Variables
   ansible.builtin.assert:
-    that: "{{ req_var }} is defined and {{ req_var }} | length > 0 and {{ req_var }} != None"
+    that: req_var is defined and req_var | length > 0 and req_var != None
     fail_msg: "{{ req_var }} needs to be set for the role to work"
     success_msg: "{{ req_var }} is defined"
     quiet: true

--- a/tox.ini
+++ b/tox.ini
@@ -2,21 +2,20 @@
 minversion = 4.0.0
 envlist =
     lint
-    py-ansible{2.16}-ubuntu20-{jre8}
-    py-ansible{2.17}-{centos9,debian11,ubuntu20,ubuntu22}-{default,root}
+    py3.11-ansible{2.17,2.18}-{ubuntu22}-default
+    py3.11-ansible{2.19}-{centos9,debian11,debian12,ubuntu22}-{default,root}
 
 [testenv]
 description =
     default: Install Omada SDN
-    jre8: Molecule scenario on Ubuntu 20.04 (JRE 8)
     root: Install Omada SDN and run as root
 deps =
-    ansible2.16: ansible-core == 2.16.*
     ansible2.17: ansible-core == 2.17.*
+    ansible2.18: ansible-core == 2.18.*
+    ansible2.19: ansible-core == 2.19.*
     -r ./requirements/dev-requirements.txt
 commands =
     default: molecule {posargs:test -s default}
-    jre8: molecule {posargs:test -s ubuntu-jre8}
     root: molecule {posargs:test -s root-user}
 setenv =
     ANSIBLE_COLLECTIONS_PATH={work_dir}/{env_name}/.ansible/collections/ansible_collections
@@ -25,7 +24,7 @@ setenv =
     MOLECULE_NAME={env_name}
     centos9: MOLECULE_IMAGE=trfore/docker-centos9-systemd
     debian11: MOLECULE_IMAGE=trfore/docker-debian11-systemd
-    ubuntu20: MOLECULE_IMAGE=trfore/docker-ubuntu2004-systemd
+    debian12: MOLECULE_IMAGE=trfore/docker-debian12-systemd
     ubuntu22: MOLECULE_IMAGE=trfore/docker-ubuntu2204-systemd
     PY_COLORS=1
     TOX_ENVNAME={env_name}


### PR DESCRIPTION
- Also drops testing for Ubuntu 20.04
- Includes depreciation notice for Ubuntu 20.04 install with JRE8